### PR TITLE
Accept "UTF-8" style encoding name and fix document

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ A CLI for [Groonga](http://groonga.org/) using Readline. Supports Windows.
 
 For example:
 
-    $ grnlip groonga ~/.milkode/db/milkode.db
+    $ grnlip groonga %HOME%\.milkode\db\milkode.db
 
 If you use UTF-8 database on Windows, you should specify the following option to use multibyte characters:
 
-    > grnlip bin\groonga \Users\myokoym\.milkode\db\milkode.db utf-8
+    > grnlip bin\groonga C:\Users\myokoym\.milkode\db\milkode.db utf-8
 
 Then, REPL by Readline for Groonga is started:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For example:
 
 If you use UTF-8 database on Windows, you should specify the following option to use multibyte characters:
 
-    > grnlip bin\groonga C:\Users\myokoym\.milkode\db\milkode.db utf-8
+    > grnlip bin\groonga %HOME%\.milkode\db\milkode.db utf-8
 
 Then, REPL by Readline for Groonga is started:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A CLI for [Groonga](http://groonga.org/) using Readline. Supports Windows.
 
 For example:
 
-    $ grnlip groonga %HOME%\.milkode\db\milkode.db
+    $ grnlip groonga ~\.milkode\db\milkode.db
 
 If you use UTF-8 database on Windows, you should specify the following option to use multibyte characters:
 

--- a/exe/grnlip
+++ b/exe/grnlip
@@ -11,7 +11,7 @@ end
 groonga_exe = ARGV.shift
 db_path = ARGV.shift
 basename = File.basename(db_path)
-db_encoding = ARGV.shift
+db_encoding = ARGV.shift.downcase
 
 if /mswin|mingw|cygwin/i =~ RUBY_PLATFORM
   input_encoding = "sjis"


### PR DESCRIPTION
- Accept `UTF-8` style encoding name 
- Use `%HOME%` instead of `~`
